### PR TITLE
Enable jshint to be skipped on individual files

### DIFF
--- a/lib/smoosh/index.js
+++ b/lib/smoosh/index.js
@@ -122,6 +122,11 @@ var _write = {
     }
   },
 
+  skip: function(key) {
+    this.message('+ Congratulations. JSHint processing was skipped.'.green);
+    this.message('  '.green + key.yellow + ' SKIPPED jshint!\n');
+  },
+
   analysis: function (type, file, oldLen, newLen){
     var fileDiff = Math.abs(oldLen - newLen).toString();
     this.message('+ The new size of ' + type.magenta + ' ' + file.magenta + ' is ' + newLen.toString().magenta + ' bytes!');
@@ -195,6 +200,9 @@ var _config = {
     if (!new RegExp('\.' + extension + '$').exec(name)) {
       name += '.' + extension;
     }
+    if (name.charAt(0) === '!') {
+      name = name.substr(1);
+    }
     return [this.STATIC_DIR[who], name].filter(clean).join('/');
   },
 
@@ -207,7 +215,7 @@ var _config = {
 
       if (who == 'JAVASCRIPT'){
         _files[[who, 'RAW'].join('_')][key] = this.config[who][key].map(function (PATH) {
-          return { path: PATH, fileContent: fs.readFileSync(that.getSourcePath(PATH, who), 'UTF-8') };
+          return { skip: PATH.charAt(0) === '!', path: PATH, fileContent: fs.readFileSync(that.getSourcePath(PATH, who), 'UTF-8') };
         });
       }
 
@@ -246,13 +254,18 @@ var _run = {
     for (bundle in bundles) {
       bundles[bundle].forEach(function (file) {
         var errors = [];
-        jshint(file.fileContent, _config.config.JSHINT_OPTS);
-        jshint.errors.forEach(function (err) {
-          if (err && err.reason != 'Expected an assignment or function call and instead saw an expression.') {
-            errors.push(err);
-          }
-        });
-        _write.jshint(file.path, errors);
+        if (!file.skip) {
+          jshint(file.fileContent, _config.config.JSHINT_OPTS);
+          jshint.errors.forEach(function (err) {
+            if (err && err.reason != 'Expected an assignment or function call and instead saw an expression.') {
+              errors.push(err);
+            }
+          });
+          _write.jshint(file.path, errors);
+        }
+        else {
+          _write.skip(file.path);
+        }
       });
     }
   }

--- a/lib/smoosh/index.js
+++ b/lib/smoosh/index.js
@@ -205,7 +205,7 @@ var _config = {
   },
 
   getSkip: function (name) {
-    return typeof name == 'string' && !name.jshint;
+    return typeof name == 'string' ? false : !name.jshint;
   },
 
   process: function (who) {

--- a/lib/smoosh/index.js
+++ b/lib/smoosh/index.js
@@ -197,13 +197,15 @@ var _config = {
 
   getSourcePath: function (name, who) {
     var extension = who == 'JAVASCRIPT' ? 'js' : 'css';
+    name = typeof name == 'string' ? name : name.src;
     if (!new RegExp('\.' + extension + '$').exec(name)) {
       name += '.' + extension;
     }
-    if (name.charAt(0) === '!') {
-      name = name.substr(1);
-    }
     return [this.STATIC_DIR[who], name].filter(clean).join('/');
+  },
+
+  getSkip: function (name) {
+    return typeof name == 'string' ? false : !name.jshint;
   },
 
   process: function (who) {
@@ -215,7 +217,8 @@ var _config = {
 
       if (who == 'JAVASCRIPT'){
         _files[[who, 'RAW'].join('_')][key] = this.config[who][key].map(function (PATH) {
-          return { skip: PATH.charAt(0) === '!', path: PATH, fileContent: fs.readFileSync(that.getSourcePath(PATH, who), 'UTF-8') };
+          var srcPath = that.getSourcePath(PATH,who);
+          return { skip: that.getSkip(PATH), path: srcPath, fileContent: fs.readFileSync(srcPath, 'UTF-8') };
         });
       }
 

--- a/lib/smoosh/index.js
+++ b/lib/smoosh/index.js
@@ -205,7 +205,7 @@ var _config = {
   },
 
   getSkip: function (name) {
-    return typeof name == 'string' ? false : !name.jshint;
+    return typeof name == 'string' && !name.jshint;
   },
 
   process: function (who) {

--- a/lib/smoosh/index.js
+++ b/lib/smoosh/index.js
@@ -205,7 +205,7 @@ var _config = {
   },
 
   getSkip: function (name) {
-    return typeof name == 'string' ? false : !name.jshint;
+    return typeof name != 'string' && !name.jshint;
   },
 
   process: function (who) {


### PR DESCRIPTION
This commit makes it possible to skip jshint processing on individual files. Simply put a bang (`!`) before the filepath to exclude that file from jshint. 

For example, the following setting will run `script.js` through jshint, but it will not run `header.js` through jshint.

```
"base": [ "!./src/header.js", "./src/script.js" ],
```

All other processing continues to take place on all files.
