### PR TITLE
Check whether a subfolder exists, if not create it

### DIFF
--- a/lib/smoosh/index.js
+++ b/lib/smoosh/index.js
@@ -1,4 +1,5 @@
 var fs = require('fs')
+    , path = require('path')
     , colors = require('colors')
     , uglifyJs = require('uglify-js')
     , jshint = require('jshint').JSHINT
@@ -339,7 +340,7 @@ var _build = {
 
     who.forEach(function (who) {
       for (file in _files[who]) {
-        fs.writeFileSync(that.getBuildPath(file, who, false), _files[who][file]);
+        that.writeFile(that.getBuildPath(file, who, false), _files[who][file]);
         _write.built('an uncompressed file', file);
       }
     });
@@ -364,7 +365,7 @@ var _build = {
 
     _files.CSS_MIN[file] = sqwish.minify(css);
 
-    fs.writeFileSync(this.getBuildPath(file, 'CSS', true), _files.CSS_MIN[file]);
+    this.writeFile(this.getBuildPath(file, 'CSS', true), _files.CSS_MIN[file]);
     _write.built('a minified file with supr lean css', file);
   },
 
@@ -380,7 +381,7 @@ var _build = {
 
     _files.JAVASCRIPT_MIN[file] += uglifyJs.uglify.gen_code(ast);
 
-    fs.writeFileSync(this.getBuildPath(file, 'JAVASCRIPT', true), _files.JAVASCRIPT_MIN[file]);
+    this.writeFile(this.getBuildPath(file, 'JAVASCRIPT', true), _files.JAVASCRIPT_MIN[file]);
     _write.built('a minified file with uglifyJs', file);
   },
 
@@ -398,6 +399,18 @@ var _build = {
         extension
       ].filter(clean).join('.')
     ].filter(clean).join('/');
+  },
+
+  writeFile: function (file, file_contents) {
+    try {
+      fs.writeFileSync(file, file_contents);
+    } catch (e) {
+      var dirPath = path.dirname(file);
+      if (!path.existsSync(dirPath)) {
+        fs.mkdirSync(dirPath, 0775);
+      }
+      fs.writeFileSync(file, file_contents);
+    }
   },
 
   showCopyright: function (comments) {


### PR DESCRIPTION
This allows for more complex generation of JS-files without the build target being flooded with JS-files.

Also - seems like the version in NPM lags behind master here a bit.
