### PR TITLE
Fix missing ending semicolon in UglifyJS output

### DIFF
--- a/lib/smoosh/index.js
+++ b/lib/smoosh/index.js
@@ -382,7 +382,7 @@ var _build = {
     ast = uglifyJs.uglify.ast_mangle(ast);
     ast = uglifyJs.uglify.ast_squeeze(ast);
 
-    _files.JAVASCRIPT_MIN[file] += uglifyJs.uglify.gen_code(ast);
+    _files.JAVASCRIPT_MIN[file] += uglifyJs.uglify.gen_code(ast).replace(/;*$/, ";");
 
     this.writeFile(this.getBuildPath(file, 'JAVASCRIPT', true), _files.JAVASCRIPT_MIN[file]);
     _write.built('a minified file with uglifyJs', file);


### PR DESCRIPTION
When files processed with smoosh (UglifyJS) are concatenated to other files, there may be a bug because of a missing semicolon at the end of the compressed output. I encountered this problem when using [ded/domready](https://github.com/ded/domready)'s minified version, which has been created with smoosh.
- The exact error is: `TypeError: (intermediate value)(...) is not a function`.
- Here is a related [SO question](https://stackoverflow.com/questions/20307462/js-cant-combine-lib-files)
- Here is [an archive of the issue in UglifyJS 1](https://web.archive.org/web/20130319222210/https://github.com/mishoo/UglifyJS/issues/126) (quite long, but very informative of the pros & cons of adding the semicolon).
- Here is [a fiddle](http://jsfiddle.net/5sxsk147/) which demonstrates the error with the smoosh output of [ded/domready](https://github.com/ded/domready) + some example code. The fix is also demonstrated.

The fix is directly taken from the UglifyJS [source code](https://github.com/mishoo/UglifyJS/blob/master/bin/uglifyjs#L257). It has to be taken care of in smoosh's code too because smoosh directly uses the UglifyJS v1 API. In UglifyJS, the semicolon is also added after the [gen_code(ast)](https://github.com/mishoo/UglifyJS/blob/master/bin/uglifyjs#L315) call.
